### PR TITLE
feat: 📄 add legal mentions page with structured content

### DIFF
--- a/src/pages/mentions-legales.astro
+++ b/src/pages/mentions-legales.astro
@@ -1,0 +1,316 @@
+---
+import Layout from "../layouts/Layout.astro";
+---
+
+<Layout>
+  <div class="mentions-legales space-y-12">
+    <h1 class="text-4xl font-extrabold uppercase">Mentions légales</h1>
+
+    <details class="bg-neutral-100 p-4">
+      <summary class="font-extrabold uppercase">Table des matières</summary>
+      <ul class="mt-4 pl-4">
+        <li><a href="#editeur-du-site">Éditeur du site</a></li>
+        <li><a href="#hebergement">Hébergement</a></li>
+        <li><a href="#developpement">Développement</a></li>
+        <li><a href="#conditions-utilisation">Conditions d'utilisation</a></li>
+        <li><a href="#cookies">Cookies</a></li>
+        <li><a href="#liens-hypertextes">Liens hypertextes</a></li>
+        <li><a href="#services-fournis">Services fournis</a></li>
+        <li>
+          <a href="#limitation-contractuelles">Limitation contractuelles</a>
+        </li>
+        <li>
+          <a href="#propriete-intellectuelle">Propriété intellectuelle</a>
+        </li>
+        <li><a href="#litiges">Litiges</a></li>
+        <li><a href="#donnees-personnelles">Données personnelles</a></li>
+      </ul>
+    </details>
+
+    <section id="editeur-du-site">
+      <h2 class="font-extrabold uppercase">Éditeur du site</h2>
+      <p>SARL LUNEDIT</p>
+      <p>SIREN : 832731319</p>
+      <p>Responsable éditorial : Lucie NEDELLEC</p>
+      <p>Email : <a href="mailto:lucie@lunedit.com">lucie@lunedit.com</a></p>
+      <p>
+        Site web : <a
+          href="https://www.lunedit.com"
+          target="_blank"
+          rel="noopener">www.lunedit.com</a
+        >
+      </p>
+    </section>
+
+    <section id="hebergement">
+      <h2 class="font-extrabold uppercase">Hébergement</h2>
+      <p>Hébergeur : Github Pages</p>
+    </section>
+
+    <section id="developpement">
+      <h2 class="font-extrabold uppercase">Développement</h2>
+      <p>
+        Réalisé par
+        <a href="https://crista-desuraune.fr" target="_blank" rel="noopener">
+          Crista Desuraune</a
+        >,
+        <a href="https://paulkaras.dev/" target="_blank" rel="noopener">
+          Paul Karas</a
+        >, sous la direction de
+        <a href="https://raphaelsanchez.design" target="_blank" rel="noopener"
+          >Raphael Sanchez</a
+        >
+      </p>
+    </section>
+
+    <section id="conditions-utilisation">
+      <h2 class="font-extrabold uppercase">Conditions d'utilisation</h2>
+      <p>
+        Ce site LUNEDIT est proposé en différents langages web (HTML, HTML5,
+        Javascript, CSS, etc…) pour un meilleur confort d'utilisation et un
+        graphisme plus agréable.
+      </p>
+      <p>
+        Nous vous recommandons de recourir à des navigateurs modernes comme
+        Internet explorer, Safari, Firefox, Google Chrome, etc…
+      </p>
+      <p>
+        LUNEDIT met en œuvre tous les moyens dont elle dispose, pour assurer une
+        information fiable et une mise à jour fiable de ses sites internet.
+        Toutefois, des erreurs ou omissions peuvent survenir.
+      </p>
+      <p>
+        L'internaute devra donc s'assurer de l'exactitude des informations
+        auprès de LUNEDIT et signaler toutes modifications du site qu'il
+        jugerait utile. LUNEDIT n'est en aucun cas responsable de l'utilisation
+        faite de ces informations, et de tout préjudice direct ou indirect
+        pouvant en découler.
+      </p>
+    </section>
+
+    <section id="cookies">
+      <h2 class="font-extrabold uppercase">Cookies</h2>
+      <p>
+        Le site LUNEDIT n'utilise pas de cookie mais peut-être amené à vous
+        demander l'acceptation des cookies pour des besoins de statistiques et
+        d'affichage.
+      </p>
+      <p>
+        Un cookie est une information déposée sur votre disque dur par le
+        serveur du site que vous visitez. Il contient plusieurs données qui sont
+        stockées sur votre ordinateur dans un simple fichier texte auquel un
+        serveur accède pour lire et enregistrer des informations. Certaines
+        parties de ce site ne peuvent être fonctionnelles sans l'acceptation de
+        cookies.
+      </p>
+    </section>
+
+    <section id="liens-hypertextes">
+      <h2 class="font-extrabold uppercase">Liens hypertextes</h2>
+      <p>
+        Les sites internet peuvent offrir des liens vers d'autres sites internet
+        ou d'autres ressources disponibles sur Internet. LUNEDIT ne dispose
+        d'aucun moyen pour contrôler les sites en connexion avec ses sites
+        internet.
+      </p>
+      <p>
+        LUNEDIT ne répond pas de la disponibilité de tels sites et sources
+        externes, ni ne la garantit. Elle ne peut être tenue pour responsable de
+        tout dommage, de quelque nature que ce soit, résultant du contenu de ces
+        sites ou sources externes, et notamment des informations, produits ou
+        services qu'ils proposent, ou de tout usage qui peut être fait de ces
+        éléments.
+      </p>
+      <p>
+        Les risques liés à cette utilisation incombent pleinement à
+        l'internaute, qui doit se conformer à leurs conditions d'utilisation.
+      </p>
+      <p>
+        Les utilisateurs, les abonnés et les visiteurs des sites internet ne
+        peuvent pas mettre en place un hyperlien en direction de <a
+          href="http://www.lunedit.com"
+          target="_blank"
+          rel="noopener">www.lunedit.com</a
+        > sans l'autorisation expresse et préalable de LUNEDIT.
+      </p>
+      <p>
+        Dans l'hypothèse où un utilisateur ou visiteur souhaiterait mettre en
+        place un hyperlien en direction d'un des sites internet de LUNEDIT, il
+        lui appartiendra d'adresser un email accessible sur le site afin de
+        formuler sa demande de mise en place d'un hyperlien.
+      </p>
+      <p>
+        LUNEDIT se réserve le droit d'accepter ou de refuser un hyperlien sans
+        avoir à en justifier sa décision.
+      </p>
+    </section>
+
+    <section id="services-fournis">
+      <h2 class="font-extrabold uppercase">Services fournis</h2>
+      <p>
+        L'ensemble des activités de la société ainsi que ses informations sont
+        présentés sur notre site LUNEDIT.
+      </p>
+      <p>
+        LUNEDIT s'efforce de fournir sur le site <a
+          href="http://www.lunedit.com"
+          target="_blank"
+          rel="noopener">www.lunedit.com</a
+        > des informations aussi précises que possible. Les renseignements figurant
+        sur le site <a
+          href="http://www.lunedit.com"
+          target="_blank"
+          rel="noopener">www.lunedit.com</a
+        > ne sont pas exhaustifs et les photos non contractuelles.
+      </p>
+      <p>
+        Ils sont donnés sous réserve de modifications ayant été apportées depuis
+        leur mise en ligne. Par ailleurs, tous les informations indiquées sur le
+        site <a href="http://www.lunedit.com" target="_blank" rel="noopener"
+          >www.lunedit.com</a
+        > sont donnés à titre indicatif, et sont susceptibles de changer ou d'évoluer
+        sans préavis.
+      </p>
+    </section>
+
+    <section id="limitation-contractuelles">
+      <h2 class="font-extrabold uppercase">
+        Limitation contractuelles sur les données
+      </h2>
+      <p>
+        Les informations contenues sur ce site sont aussi précises que possible
+        et le site est mis à jour à différentes périodes de l'année, mais peut
+        toutefois contenir des inexactitudes ou des omissions.
+      </p>
+      <p>
+        Si vous constatez une lacune, erreur ou ce qui parait être un
+        dysfonctionnement, merci de bien vouloir le signaler par courriel, à
+        l'adresse <a href="mailto:lucie@lunedit.com">lucie@lunedit.com</a>, en
+        décrivant le problème de la manière la plus précise possible (page
+        posant problème, type d'ordinateur et de navigateur utilisé…).
+      </p>
+      <p>
+        Tout contenu téléchargé se fait aux risques et périls de l'utilisateur
+        et sous sa seule responsabilité. En conséquence, LUNEDIT ne saurait être
+        tenu responsable d'un quelconque dommage subi par l'ordinateur de
+        l'utilisateur ou d'une quelconque perte de données consécutives au
+        téléchargement.
+      </p>
+      <p>
+        De plus, l'utilisateur du site s'engage à accéder au site en utilisant
+        un matériel récent, ne contenant pas de virus et avec un navigateur de
+        dernière génération mis-à-jour.
+      </p>
+      <p>
+        Les liens hypertextes mis en place dans le cadre du présent site
+        internet en direction d'autres ressources présentes sur le réseau
+        Internet ne sauraient engager la responsabilité de LUNEDIT.
+      </p>
+    </section>
+
+    <section id="propriete-intellectuelle">
+      <h2 class="font-extrabold uppercase">Propriété intellectuelle</h2>
+      <p>
+        Tout le contenu du présent site LUNEDIT, incluant, de façon non
+        limitative, les graphismes, images, textes, vidéos, animations, sons,
+        logos, gifs et icônes ainsi que leur mise en forme sont la propriété
+        exclusive de la société à l'exception des marques, logos ou contenus
+        appartenant à d'autres sociétés partenaires ou auteurs.
+      </p>
+      <p>
+        Toute reproduction, distribution, modification, adaptation,
+        retransmission ou publication, même partielle, de ces différents
+        éléments est strictement interdite sans l'accord exprès par écrit de
+        LUNEDIT. Cette représentation ou reproduction, par quelque procédé que
+        ce soit, constitue une contrefaçon sanctionnée par les articles L.335-2
+        et suivants du Code de la propriété intellectuelle. Le non-respect de
+        cette interdiction constitue une contrefaçon pouvant engager la
+        responsabilité civile et pénale du contrefacteur. En outre, les
+        propriétaires des Contenus copiés pourraient intenter une action en
+        justice à votre encontre.
+      </p>
+    </section>
+
+    <section id="litiges">
+      <h2 class="font-extrabold uppercase">Litiges</h2>
+      <p>
+        Les présentes conditions du site <a
+          href="http://www.lunedit.com"
+          target="_blank"
+          rel="noopener">www.lunedit.com</a
+        > sont régies par les lois françaises et toute contestation ou litiges qui
+        pourraient naître de l'interprétation ou de l'exécution de celles-ci seront
+        de la compétence exclusive des tribunaux dont dépend le siège social de la
+        société. La langue de référence, pour le règlement de contentieux éventuels,
+        est le français.
+      </p>
+    </section>
+
+    <section id="donnees-personnelles">
+      <h2 class="font-extrabold uppercase">Données personnelles</h2>
+      <p>
+        De manière générale, vous n'êtes pas tenu de nous communiquer vos
+        données personnelles lorsque vous visitez notre site internet LUNEDIT.
+      </p>
+      <p>Cependant, ce principe comporte certaines exceptions.</p>
+      <p>
+        En effet, pour certains services proposés par notre site, vous pouvez
+        être amenés à nous communiquer des données telles que : votre nom, votre
+        fonction, le nom de votre société, votre adresse électronique, et votre
+        numéro de téléphone. Tel est le cas lorsque vous remplissez le
+        formulaire qui vous est proposé en ligne, dans la rubrique « contact ».
+      </p>
+      <p>
+        Il est à noter que vous pouvez refuser de fournir vos données
+        personnelles. Dans ce cas, vous ne pourrez pas utiliser les services du
+        site, notamment celui de solliciter des renseignements sur notre
+        société, ou de recevoir les lettres d'information.
+      </p>
+      <p>
+        Enfin, nous pouvons collecter de manière automatique certaines
+        informations vous concernant lors d'une simple navigation sur notre site
+        internet, notamment des informations concernant l'utilisation de notre
+        site, comme les zones que vous visitez et les services auxquels vous
+        accédez, votre adresse IP, le type de votre navigateur, vos temps
+        d'accès.
+      </p>
+      <p>
+        De telles informations sont utilisées exclusivement à des fins de
+        statistiques internes, de manière à améliorer la qualité des services
+        qui vous sont proposés.
+      </p>
+      <p>
+        Les bases de données sont protégées par les dispositions de la loi du
+        1er juillet 1998 transposant la directive 96/9 du 11 mars 1996 relative
+        à la protection juridique des bases de données.
+      </p>
+    </section>
+  </div>
+
+  <style>
+    .mentions-legales {
+      max-width: 800px;
+      margin: 0 auto;
+      padding: 2rem;
+      line-height: 1.6;
+    }
+
+    .mentions-legales h2 {
+      color: #555;
+      margin-bottom: 1rem;
+      font-size: 1.3rem;
+    }
+
+    .mentions-legales a {
+      text-decoration: underline;
+    }
+
+    .mentions-legales a:hover {
+      text-decoration: underline;
+    }
+
+    .mentions-legales p {
+      margin-bottom: 1rem;
+    }
+  </style>
+</Layout>


### PR DESCRIPTION
This pull request introduces a new legal notice page (`mentions-legales`) to the project, providing comprehensive legal information and improving transparency for users. The page includes structured sections, styled content, and navigation links for ease of access.

### Addition of a Legal Notice Page:

* **New Page Implementation**: Created `mentions-legales.astro` to serve as the legal notice page with structured sections such as "Éditeur du site," "Hébergement," "Conditions d'utilisation," and more. Each section provides detailed legal and operational information about the website and its services.

* **Navigation and Accessibility**: Added a table of contents with links to each section for improved user navigation.

### Styling Enhancements:

* **Custom Styling**: Introduced CSS styles directly within the page to ensure consistent formatting, including typography, spacing, and link behavior. These styles enhance readability and maintain visual coherence.