### PR TITLE
feat: 🎨 replace Image with Picture component for better image handling

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -5,6 +5,7 @@ import ContactInfo from "./ContactInfo.astro";
 import data from "../data/infoGeneral.json";
 import { Image } from "astro:assets";
 import jaguar from "../assets/images/jaguar.png";
+import { Picture } from "astro:assets";
 
 const { address, mail, phone } = data.contact;
 ---
@@ -28,11 +29,17 @@ const { address, mail, phone } = data.contact;
       <div
         class="flex flex-col items-center gap-6 md:flex-row md:items-start md:gap-10"
       >
-        <Image
+        <Picture
           src={jaguar}
           alt="Logo Lunedit - illustration jaguar"
           class="h-24 w-auto shrink-0 md:h-32"
           loading="lazy"
+          formats={["avif", "webp", "jpeg"]}
+          width={100}
+          height={100}
+          sizes="(max-width: 720px) 100px, 150px"
+          decoding="async"
+          quality={80}
         />
         <ContactInfo
           address={address}

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -7,7 +7,7 @@ import logoImage from "../assets/images/logo-lunedit.png";
 import { navigation } from "../data/navigation.json";
 import { social } from "../data/infoGeneral.json";
 
-import { Image } from "astro:assets";
+import { Image, Picture } from "astro:assets";
 
 const isHome = Astro.url.pathname === "/";
 ---
@@ -21,17 +21,17 @@ const isHome = Astro.url.pathname === "/";
       class="rounded focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-current"
       aria-label="Accéder à la page d'accueil"
     >
-      <Image
+      <Picture
         src={logoImage}
         width={150}
         height={53}
         alt="Logo de Lunedit"
-        format="webp"
-        quality={90}
-        loading="eager"
+        formats={["avif", "webp", "jpeg"]}
+        width={150}
+        height={53}
+        sizes="(max-width: 720px) 150px, 150px"
         decoding="async"
-        densities={[1, 2]}
-        sizes="150px"
+        quality={80}
       />
     </a>
 

--- a/src/components/InstagramFeed.astro
+++ b/src/components/InstagramFeed.astro
@@ -1,5 +1,6 @@
 ---
 import Button from "../components/ui/Button.astro";
+import { Picture } from "astro:assets";
 import { Image } from "astro:assets";
 import { getCollection } from "astro:content";
 
@@ -17,14 +18,16 @@ const instagramFeeds = await getCollection("instagramFeeds");
         {
           instagramFeeds.map((feed) => (
             <div class="aspect-[1/1] w-full overflow-hidden rounded-md shadow-sm">
-              <Image
+              <Picture
                 src={feed.data.image as ImageMetadata}
                 alt={`Publication Instagram - ${feed.data.alt}`}
                 class="h-full w-full object-cover"
                 loading="lazy"
-                format="webp"
+                formats={["avif", "webp", "jpeg"]}
+                decoding="async"
                 quality={80}
-                widths={[300, 600]}
+                width={300}
+                height={300}
                 sizes="(max-width: 640px) 50vw, (max-width: 768px) 33vw, 25vw"
               />
             </div>

--- a/src/components/PartnersList.astro
+++ b/src/components/PartnersList.astro
@@ -1,4 +1,5 @@
 ---
+import { Picture } from "astro:assets";
 import { Image } from "astro:assets";
 import { getCollection } from "astro:content";
 
@@ -15,17 +16,18 @@ const partners = await getCollection("partners");
       <div class="grid grid-cols-3 gap-x-4 pb-4 md:pb-0 lg:grid-cols-5">
         {partners.map((partner, index) => (
           <div class="flex flex-shrink-0 items-center justify-center md:flex-shrink">
-            <Image
+            <Picture
               src={partner.data.image as ImageMetadata}
               alt={partner.data.alt}
               width={150}
               height={150}
-              loading={index < 6 ? "eager" : "lazy"}
+              formats={["avif", "webp", "jpeg"]}
+              width={300}
+              height={300}
+              sizes="(max-width: 720px) 200px, 300px"
+              loading="lazy"
               decoding="async"
-              format="webp"
               quality={75}
-              widths={[100, 150, 200]}
-              sizes="(max-width: 768px) 100px, 150px"
             />
           </div>
         ))}

--- a/src/components/ServicesList.astro
+++ b/src/components/ServicesList.astro
@@ -1,4 +1,5 @@
 ---
+import { Picture } from "astro:assets";
 import { Image } from "astro:assets";
 import { getCollection } from "astro:content";
 
@@ -27,12 +28,17 @@ const services = await getCollection("services");
       <div class="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-5 ">
         {services.map((service) => (
           <div class="flex flex-col items-center gap-4">
-            <Image
+            <Picture
               src={service.data.image as ImageMetadata}
               alt={service.data.alt}
               width={200}
               height={200}
               loading="lazy"
+              formats={["avif", "webp", "jpeg"]}
+              width={200}
+              height={200}
+              decoding="async"
+              quality={80}
             />
             <p class="font-heading text-foreground text-base font-bold uppercase">
               {service.data.title}


### PR DESCRIPTION
This pull request updates the image handling across multiple components by replacing the `Image` component with the more flexible `Picture` component from `astro:assets`. This change improves image optimization by supporting multiple formats and additional attributes for better performance and responsiveness.

### Image Handling Updates:

* **Footer Component (`src/components/Footer.astro`)**:
  - Replaced `Image` with `Picture` for the jaguar logo, adding support for multiple formats (`avif`, `webp`, `jpeg`), responsive sizes, and improved loading/decoding attributes. [[1]](diffhunk://#diff-9f7d7eae483a60a6aa76bcb68acc770e441d441ce02d414637694162983e6159R8) [[2]](diffhunk://#diff-9f7d7eae483a60a6aa76bcb68acc770e441d441ce02d414637694162983e6159L31-R42)

* **Header Component (`src/components/Header.astro`)**:
  - Updated the Lunedit logo to use `Picture`, enabling multiple formats, responsive sizes, and consistent decoding and quality attributes. [[1]](diffhunk://#diff-cef92c86af879f90a7ac8087da782381ed31160251d9960fe59f7ee29389a9beL10-R10) [[2]](diffhunk://#diff-cef92c86af879f90a7ac8087da782381ed31160251d9960fe59f7ee29389a9beL24-R34)

* **Instagram Feed Component (`src/components/InstagramFeed.astro`)**:
  - Switched to `Picture` for Instagram feed images, introducing multi-format support, responsive dimensions, and optimized decoding. [[1]](diffhunk://#diff-f753bbe91deb2be5f30c2a6a559e9c3e7566d2e95a4194806c9f7ab2a8782499R3) [[2]](diffhunk://#diff-f753bbe91deb2be5f30c2a6a559e9c3e7566d2e95a4194806c9f7ab2a8782499L20-R30)

* **Partners List Component (`src/components/PartnersList.astro`)**:
  - Replaced `Image` with `Picture` for partner logos, adding multi-format support, larger dimensions, and consistent lazy loading. [[1]](diffhunk://#diff-e9985f94a1c707a1b1d2d85e5f5ab4fecbd175852abee6b9557149e5020923b8R2) [[2]](diffhunk://#diff-e9985f94a1c707a1b1d2d85e5f5ab4fecbd175852abee6b9557149e5020923b8L18-L28)

* **Services List Component (`src/components/ServicesList.astro`)**:
  - Updated service images to use `Picture`, ensuring better format support, consistent dimensions, and optimized quality settings. [[1]](diffhunk://#diff-1b1c5b8a98bfb9ae9cc5361127468f8cee98fb0cc071c1e8f2eb9d71a8412911R2) [[2]](diffhunk://#diff-1b1c5b8a98bfb9ae9cc5361127468f8cee98fb0cc071c1e8f2eb9d71a8412911L30-R41)