### PR TITLE
fix: 🐛 correct text in Hero component for consistency

### DIFF
--- a/src/components/About.astro
+++ b/src/components/About.astro
@@ -97,8 +97,7 @@ import Button from "./ui/Button.astro";
   section {
     position: relative;
   }
-  section::before,
-  section::after {
+  section::before {
     content: "";
     width: 40%;
     height: 4px;
@@ -108,9 +107,5 @@ import Button from "./ui/Button.astro";
   section::before {
     right: 0;
     top: 0;
-  }
-  section::after {
-    left: 0;
-    bottom: 0;
   }
 </style>

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -8,7 +8,7 @@ import { Image } from "astro:assets";
 <header id="hero" class="hero-section bg-primary relative">
   <div class="hero-content relative z-10 space-y-8 py-32">
     <h1 class="text-balance text-5xl font-bold lg:text-6xl">
-      Gagner du temps et de la sérénité en confiant vos projets de livres à
+      Gagnez du temps et de la sérénité en confiant vos projets de livres à
       Lunedit
     </h1>
     <p class="font-base text-xl font-medium">


### PR DESCRIPTION
This pull request includes updates to the `About.astro` and `Hero.astro` components, focusing on styling adjustments and a minor text correction.

### Styling Adjustments:
* Removed the `section::after` pseudo-element styling from the `About.astro` component, leaving only the `section::before` pseudo-element for visual effects. (`src/components/About.astro`, [[1]](diffhunk://#diff-5c0cd4b211ee2a2e8171d9af7c0e77b931124958aa8a447cb3b9a0d5405b8a49L100-R100) [[2]](diffhunk://#diff-5c0cd4b211ee2a2e8171d9af7c0e77b931124958aa8a447cb3b9a0d5405b8a49L112-L115)

### Text Correction:
* Fixed a grammatical issue in the `Hero.astro` component by changing "Gagner" to "Gagnez" to ensure proper conjugation in the French text. (`src/components/Hero.astro`, [src/components/Hero.astroL11-R11](diffhunk://#diff-289237df7e7f2ebc1fa52e3aabba5f9a6599c1e53067fbf127b9d3a6b8943ab0L11-R11))